### PR TITLE
Fix linter errors and bump version to 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "elastic-docs-v3-utilities",
   "displayName": "Elastic Docs V3 Utilities",
   "description": "VSCode extension for Elastic Docs V3 Markdown authoring with directive autocompletion",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "publisher": "elastic",
   "repository": {
     "type": "git",

--- a/src/substitutionHoverProvider.ts
+++ b/src/substitutionHoverProvider.ts
@@ -20,12 +20,8 @@
 import * as vscode from 'vscode';
 import { outputChannel } from './logger';
 import { getSubstitutions, resolveShorthand } from './substitutions';
-import { parseSubstitution, describeMutationChain, MUTATION_OPERATORS } from './mutations';
+import { parseSubstitution, MUTATION_OPERATORS } from './mutations';
 import { applyMutationChain } from './mutationEngine';
-
-interface SubstitutionVariables {
-    [key: string]: string;
-}
 
 export class SubstitutionHoverProvider implements vscode.HoverProvider {
     provideHover(


### PR DESCRIPTION
- Remove unused describeMutationChain import
- Remove unused SubstitutionVariables interface
- Bump version to 0.10.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)