### PR TITLE
Fix docs-builder update version checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elastic-docs-v3-utilities",
-  "version": "0.16.1",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elastic-docs-v3-utilities",
-      "version": "0.16.1",
+      "version": "0.17.1",
       "dependencies": {
         "yaml": "^2.8.4"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "elastic-docs-v3-utilities",
   "displayName": "Elastic Docs Utilities",
   "description": "Utilities for Elastic Docs authoring",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "publisher": "Elastic",
   "repository": {
     "type": "git",

--- a/src/docsBuilderUpdateChecker.ts
+++ b/src/docsBuilderUpdateChecker.ts
@@ -22,6 +22,25 @@ import { outputChannel } from './logger';
 import { isWeb } from './fileSystem';
 
 const DOCS_BUILDER_INSTALL_URL = 'https://www.elastic.co/docs/contribute-docs/locally';
+const GITHUB_RELEASES_PATH = '/repos/elastic/docs-builder/releases?per_page=30';
+
+type SemVer = {
+    major: number;
+    minor: number;
+    patch: number;
+    prerelease: string | null;
+};
+
+type InstalledVersion = {
+    version: string | null;
+    rawVersion: string | null;
+};
+
+type GitHubRelease = {
+    tag_name?: unknown;
+    draft?: unknown;
+    prerelease?: unknown;
+};
 
 // Install commands per platform (from the official docs)
 const INSTALL_COMMANDS: Record<string, string> = {
@@ -73,7 +92,18 @@ export class DocsBuilderUpdateChecker {
                 return;
             }
 
-            outputChannel.appendLine(`docs-builder update check: Installed version is ${installedVersion}`);
+            if (!installedVersion.version) {
+                const rawVersion = installedVersion.rawVersion ? ` (${installedVersion.rawVersion})` : '';
+                outputChannel.appendLine(`docs-builder update check: Installed version is not valid semver${rawVersion}`);
+                if (isManual) {
+                    vscode.window.showWarningMessage(
+                        `docs-builder is installed, but its version output is not valid semver${rawVersion}.`
+                    );
+                }
+                return;
+            }
+
+            outputChannel.appendLine(`docs-builder update check: Installed version is ${installedVersion.version}`);
 
             const latestVersion = await this.getLatestGitHubVersion();
 
@@ -81,7 +111,7 @@ export class DocsBuilderUpdateChecker {
                 outputChannel.appendLine('docs-builder update check: Could not fetch latest version from GitHub');
                 if (isManual) {
                     vscode.window.showWarningMessage(
-                        `docs-builder ${installedVersion} is installed, but the latest version could not be determined. Check your network connection.`
+                        `docs-builder ${installedVersion.version} is installed, but the latest version could not be determined. Check your network connection.`
                     );
                 }
                 return;
@@ -89,14 +119,14 @@ export class DocsBuilderUpdateChecker {
 
             outputChannel.appendLine(`docs-builder update check: Latest version is ${latestVersion}`);
 
-            if (this.isNewerVersion(latestVersion, installedVersion)) {
-                outputChannel.appendLine(`docs-builder update check: Update available (${installedVersion} -> ${latestVersion})`);
-                await this.showUpdateNotification(installedVersion, latestVersion);
+            if (this.isNewerVersion(latestVersion, installedVersion.version)) {
+                outputChannel.appendLine(`docs-builder update check: Update available (${installedVersion.version} -> ${latestVersion})`);
+                await this.showUpdateNotification(installedVersion.version, latestVersion);
             } else {
                 outputChannel.appendLine('docs-builder update check: Installation is up to date');
                 if (isManual) {
                     vscode.window.showInformationMessage(
-                        `docs-builder is up to date (${installedVersion}).`
+                        `docs-builder is up to date (${installedVersion.version}).`
                     );
                 }
             }
@@ -107,10 +137,10 @@ export class DocsBuilderUpdateChecker {
 
     /**
      * Get the installed docs-builder version by running `docs-builder --version`.
-     * Parses the version from the last non-empty line of stdout.
-     * Returns null if docs-builder is not installed or not in PATH.
+     * Parses the version from the last non-empty line of stdout that is valid semver.
+     * Returns null only if docs-builder is not installed or not in PATH.
      */
-    private async getInstalledVersion(): Promise<string | null> {
+    private async getInstalledVersion(): Promise<InstalledVersion | null> {
         return new Promise((resolve) => {
             try {
                 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -123,7 +153,7 @@ export class DocsBuilderUpdateChecker {
                         return;
                     }
 
-                    // The version is on the last non-empty line of stdout.
+                    // The version should be on the last non-empty line of stdout.
                     // Example output:
                     //   info ::e.d.c.tionFileProvider:: ConfigurationSource.Embedded ...
                     //   info ::m.h.Lifetime          :: Application started. ...
@@ -131,19 +161,11 @@ export class DocsBuilderUpdateChecker {
                     //   info ::m.h.Lifetime          :: Content root path: /some/path
                     //   0.112.0
                     const output = (stdout || '') + (stderr || '');
-                    const lines = output.split('\n').map(l => l.trim()).filter(l => l.length > 0);
-
-                    // Find the last line that looks like a version number
-                    for (let i = lines.length - 1; i >= 0; i--) {
-                        const versionMatch = lines[i].match(/^(\d+\.\d+\.\d+.*)$/);
-                        if (versionMatch) {
-                            resolve(versionMatch[1]);
-                            return;
-                        }
+                    const parsedVersion = this.parseInstalledVersionOutput(output);
+                    if (!parsedVersion.version) {
+                        outputChannel.appendLine(`docs-builder update check: Could not parse semver from output: ${output}`);
                     }
-
-                    outputChannel.appendLine(`docs-builder update check: Could not parse version from output: ${output}`);
-                    resolve(null);
+                    resolve(parsedVersion);
                 });
             } catch (err) {
                 outputChannel.appendLine(`docs-builder update check: Error spawning process: ${err}`);
@@ -154,7 +176,7 @@ export class DocsBuilderUpdateChecker {
 
     /**
      * Fetch the latest release version from the GitHub API.
-     * Uses the /releases/latest endpoint which excludes drafts and pre-releases.
+     * Uses the releases list so drafts and pre-releases are filtered explicitly.
      * Includes a timeout to prevent hanging on slow networks.
      * Fails silently and returns null on any error.
      */
@@ -168,7 +190,7 @@ export class DocsBuilderUpdateChecker {
 
                 const options = {
                     hostname: 'api.github.com',
-                    path: '/repos/elastic/docs-builder/releases/latest',
+                    path: GITHUB_RELEASES_PATH,
                     method: 'GET',
                     timeout: TIMEOUT_MS,
                     headers: {
@@ -192,14 +214,26 @@ export class DocsBuilderUpdateChecker {
                                 return;
                             }
 
-                            const release = JSON.parse(data);
-                            const tagName = release.tag_name;
-                            if (tagName) {
-                                // Remove leading 'v' if present
-                                resolve(tagName.startsWith('v') ? tagName.substring(1) : tagName);
-                            } else {
+                            const releases = JSON.parse(data);
+                            if (!Array.isArray(releases)) {
+                                outputChannel.appendLine('docs-builder update check: GitHub API response was not a release list');
                                 resolve(null);
+                                return;
                             }
+
+                            for (const release of releases as GitHubRelease[]) {
+                                if (release.draft === true || release.prerelease === true || typeof release.tag_name !== 'string') {
+                                    continue;
+                                }
+
+                                const version = this.parseSemVer(release.tag_name);
+                                if (version) {
+                                    resolve(this.formatSemVer(version));
+                                    return;
+                                }
+                            }
+
+                            resolve(null);
                         } catch (err) {
                             outputChannel.appendLine(`docs-builder update check: Failed to parse GitHub response: ${err}`);
                             resolve(null);
@@ -232,27 +266,109 @@ export class DocsBuilderUpdateChecker {
      * Returns true if remoteVersion is newer than localVersion.
      */
     private isNewerVersion(remoteVersion: string, localVersion: string): boolean {
-        // Normalize versions by removing 'v' prefix if present
-        const remote = remoteVersion.replace(/^v/, '');
-        const local = localVersion.replace(/^v/, '');
+        const remote = this.parseSemVer(remoteVersion);
+        const local = this.parseSemVer(localVersion);
+        if (!remote || !local) {
+            return false;
+        }
 
-        const remoteParts = remote.split('.').map(p => parseInt(p, 10) || 0);
-        const localParts = local.split('.').map(p => parseInt(p, 10) || 0);
+        for (const key of ['major', 'minor', 'patch'] as const) {
+            if (remote[key] > local[key]) return true;
+            if (remote[key] < local[key]) return false;
+        }
 
-        // Ensure both have at least 3 parts
-        while (remoteParts.length < 3) remoteParts.push(0);
-        while (localParts.length < 3) localParts.push(0);
+        if (!remote.prerelease && local.prerelease) {
+            return true;
+        }
+        if (remote.prerelease && !local.prerelease) {
+            return false;
+        }
 
-        for (let i = 0; i < 3; i++) {
-            if (remoteParts[i] > localParts[i]) {
-                return true;
+        return this.comparePrerelease(remote.prerelease, local.prerelease) > 0;
+    }
+
+    private parseInstalledVersionOutput(output: string): InstalledVersion {
+        const lines = output.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+        let rawVersion: string | null = null;
+
+        for (let i = lines.length - 1; i >= 0; i--) {
+            const exactVersion = this.parseSemVer(lines[i]);
+            if (exactVersion) {
+                return {
+                    version: this.formatSemVer(exactVersion),
+                    rawVersion: lines[i]
+                };
             }
-            if (remoteParts[i] < localParts[i]) {
-                return false;
+
+            const versionLikeMatch = lines[i].match(/\bv?\d+(?:\.\d+){2,}(?:[-+][0-9A-Za-z.-]+)?\b/);
+            if (!rawVersion && versionLikeMatch) {
+                rawVersion = versionLikeMatch[0];
             }
         }
 
-        return false; // Versions are equal
+        return {
+            version: null,
+            rawVersion
+        };
+    }
+
+    private parseSemVer(version: string): SemVer | null {
+        // docs-builder's native binary currently reports a .NET-style assembly
+        // version such as 1.10.0.0. Treat a trailing .0 revision as semver.
+        const match = version.trim().match(/^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.0)?(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/);
+        if (!match) {
+            return null;
+        }
+
+        return {
+            major: Number(match[1]),
+            minor: Number(match[2]),
+            patch: Number(match[3]),
+            prerelease: match[4] || null
+        };
+    }
+
+    private formatSemVer(version: SemVer): string {
+        const prerelease = version.prerelease ? `-${version.prerelease}` : '';
+        return `${version.major}.${version.minor}.${version.patch}${prerelease}`;
+    }
+
+    private comparePrerelease(remotePrerelease: string | null, localPrerelease: string | null): number {
+        if (remotePrerelease === localPrerelease) {
+            return 0;
+        }
+        if (!remotePrerelease) {
+            return 1;
+        }
+        if (!localPrerelease) {
+            return -1;
+        }
+
+        const remoteParts = remotePrerelease.split('.');
+        const localParts = localPrerelease.split('.');
+        const length = Math.max(remoteParts.length, localParts.length);
+
+        for (let i = 0; i < length; i++) {
+            const remotePart = remoteParts[i];
+            const localPart = localParts[i];
+
+            if (remotePart === undefined) return -1;
+            if (localPart === undefined) return 1;
+            if (remotePart === localPart) continue;
+
+            const remoteNumeric = /^\d+$/.test(remotePart);
+            const localNumeric = /^\d+$/.test(localPart);
+
+            if (remoteNumeric && localNumeric) {
+                return Number(remotePart) > Number(localPart) ? 1 : -1;
+            }
+            if (remoteNumeric) return -1;
+            if (localNumeric) return 1;
+
+            return remotePart > localPart ? 1 : -1;
+        }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Ignore draft and prerelease docs-builder releases when checking for updates.
- Normalize docs-builder version output before comparing, including .NET-style trailing `.0` versions.
- Compare versions with semver-aware numeric ordering so releases like `1.10.0` are handled correctly.

## Test plan
- `npm run compile:test`.
- `npm run lint -- --quiet`.
- `npm test`.
- `npm run compile`.


Made with [Cursor](https://cursor.com)